### PR TITLE
Fix "insertRule accepts only strings" problem

### DIFF
--- a/components/ButtonDarkStyle.js
+++ b/components/ButtonDarkStyle.js
@@ -1,0 +1,7 @@
+import css from 'styled-jsx/css';
+
+export default css`.btn--dark {
+  background-color: #bbc8d5;
+  border: 1px solid #bbc8d5;
+  color: #333;
+}`;

--- a/components/ButtonStyle.js
+++ b/components/ButtonStyle.js
@@ -1,4 +1,6 @@
-export const ButtonStyle = `.btn {
+import css from 'styled-jsx/css';
+
+export default css`.btn {
   background-color: transparent;
   border: 1px solid #666;
   border-radius: 50px;
@@ -6,10 +8,4 @@ export const ButtonStyle = `.btn {
   cursor: pointer;
   line-height: 28px;
   padding: 0 15px;
-}`;
-
-export const ButtonDarkStyle = `.btn--dark {
-  background-color: #bbc8d5;
-  border: 1px solid #bbc8d5;
-  color: #333;
 }`;

--- a/components/Devices.js
+++ b/components/Devices.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 
-import { ButtonStyle, ButtonDarkStyle } from './ButtonStyle';
+import ButtonStyle from './ButtonStyle';
+import ButtonDarkStyle from './ButtonDarkStyle';
 import { fetchAvailableDevices, transferPlaybackToDevice } from '../actions/devicesActions';
 import { getIsFetchingDevices } from '../reducers';
 import { getDevices } from '../reducers';

--- a/components/Header.js
+++ b/components/Header.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { login } from '../actions/sessionActions';
 import { mutePlayback, unmutePlayback } from '../actions/playbackActions';
-import { ButtonStyle, ButtonDarkStyle } from './ButtonStyle';
+import ButtonStyle from './ButtonStyle';
+import ButtonDarkStyle from './ButtonDarkStyle';
 
 const linkStyle = {
   lineHeight: '30px',


### PR DESCRIPTION
Looking at [the next.js issue](https://github.com/zeit/next.js/issues/3442), I was redirected to another [styled-jsx issue](https://github.com/zeit/styled-jsx/issues/322). Here it is clarified that using constants they way they are used now is not recommended.

[Coox](https://github.com/coox) shares a couple example files that clarify how to use the constants:
- [lib/styled-jsx-css.js](https://github.com/coox/styled-jsx-unexpected-curly-braces/blob/master/lib/styled-jsx-css.js)
- [index.js](https://github.com/coox/styled-jsx-unexpected-curly-braces/blob/master/pages/index.js)

Based on them I've developed this fix that allows one to start the project without the ugly `"insertRule accepts only strings"` error.

Full disclaimer, I know nothing about React. :upside_down_face: 